### PR TITLE
Add *.sublime-macro file syncing?

### DIFF
--- a/Package Syncing.sublime-settings
+++ b/Package Syncing.sublime-settings
@@ -12,6 +12,7 @@
 		"*.sublime-keymap",
 		"*.sublime-settings",
 		"*.sublime-snippet",
+		"*.sublime-macro",
 		"*.tmLanguage",
 		"*.tmTheme"
 	],


### PR DESCRIPTION
Like `*.sublime-snippet` file syncing, is there any reason why `*.sublime-macro` files shouldn't be synced by default as well?  Maybe this could be added? :)
