### PR TITLE
Fix for placement of menus

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -1,35 +1,5 @@
 [
 	{
-		"caption": "Preferences",
-		"mnemonic": "n",
-		"id": "preferences",
-		"children":
-		[
-			{
-				"caption": "Package Settings",
-				"mnemonic": "P",
-				"id": "package-settings",
-				"children":
-				[
-					{
-						"caption": "Package Syncing",
-						"children":
-						[
-							{
-								"caption": "Settings – Default",
-								"command": "open_file", "args": { "file": "${packages}/Package Syncing/Package Syncing.sublime-settings" }
-							},
-							{
-								"caption": "Settings – User",
-								"command": "open_file", "args": { "file": "${packages}/User/Package Syncing.sublime-settings" }
-							}
-						]
-					}
-				]
-			}
-		]
-	},
-	{
 		"id": "tools",
 		"children":
 		[
@@ -65,6 +35,36 @@
 								"command": "pkg_sync", "args": {"mode": ["pull"]}
 							},
 							{ "caption": "-" },
+							{
+								"caption": "Settings – Default",
+								"command": "open_file", "args": { "file": "${packages}/Package Syncing/Package Syncing.sublime-settings" }
+							},
+							{
+								"caption": "Settings – User",
+								"command": "open_file", "args": { "file": "${packages}/User/Package Syncing.sublime-settings" }
+							}
+						]
+					}
+				]
+			}
+		]
+	},
+	{
+		"caption": "Preferences",
+		"mnemonic": "n",
+		"id": "preferences",
+		"children":
+		[
+			{
+				"caption": "Package Settings",
+				"mnemonic": "P",
+				"id": "package-settings",
+				"children":
+				[
+					{
+						"caption": "Package Syncing",
+						"children":
+						[
 							{
 								"caption": "Settings – Default",
 								"command": "open_file", "args": { "file": "${packages}/Package Syncing/Package Syncing.sublime-settings" }


### PR DESCRIPTION
Sublime Text regards the document order in it's setting's JSON, so a menu document with `"id": "tools"` placed after a menu document with `"id": "packages",` causes Sublime Text to put the `tools` menu in an menu with no label, tooltip, or visible icon. The documents ought to be in the order as they appear within the menus themselves, from left to right: ![ST3 Menubar](http://i.imgur.com/zmOcBwB.png)